### PR TITLE
prom: missing include for 'sprintf'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,11 @@
 .vscode
 prom/build
 prom/build.test
+prom/tags
 promhttp/build
+promhttp/tags
 promtest/build
+promtest/tags
 example/example
 docs/html
 docs/latex

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ To test the libs, run `make test`.
 
 If you do not want to compile libprom by yourself, any successful CI job on the [Github Action Page](https://github.com/jelmd/libprom/actions) contains the libprom archive for x86_64 Ubuntu, where the CI tests have been run. Just click on a CI job and scroll down to the **Artifacts** section. On Linux they probably work on most more or less recent distributions.
 
+Last but not least you may try the Ubuntu packages hosted on [https://pkg.cs.ovgu.de/LNF/linux/ubuntu](https://pkg.cs.ovgu.de/LNF/linux/ubuntu)/**release**/.
+
 API, Documentation, Usage
 -------------------------
 - https://jelmd.github.io/libprom/

--- a/prom/src/prom_histogram_buckets.c
+++ b/prom/src/prom_histogram_buckets.c
@@ -17,6 +17,7 @@
 
 #include <stdarg.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 // Public
 #include "prom_alloc.h"


### PR DESCRIPTION
> /<<PKGBUILDDIR>>/prom/src/prom_histogram_buckets.c: In function ‘double_to_str’:
> /<<PKGBUILDDIR>>/prom/src/prom_histogram_buckets.c:34:19: error: implicit declaration of function ‘sprintf’ [-Werror=implicit-function-declaration]
>    34 |         int len = sprintf(buf, "%.17g", value);
>       |                   ^~~~~~~
> /<<PKGBUILDDIR>>/prom/src/prom_histogram_buckets.c:28:1: note: include ‘<stdio.h>’ or provide a declaration of ‘sprintf’
>    27 | #include "prom_log.h"
>   +++ |+#include <stdio.h>
>    28 |
> /<<PKGBUILDDIR>>/prom/src/prom_histogram_buckets.c:34:19: error: incompatible implicit declaration of built-in function ‘sprintf’ [-Werror=builtin-declaration-mismatch]
>    34 |         int len = sprintf(buf, "%.17g", value);
>       |                   ^~~~~~~
> /<<PKGBUILDDIR>>/prom/src/prom_histogram_buckets.c:34:19: note: include ‘<stdio.h>’ or provide a declaration of ‘sprintf’